### PR TITLE
flashloanFeePercentage

### DIFF
--- a/solend-sdk/src/classes/reserve.ts
+++ b/solend-sdk/src/classes/reserve.ts
@@ -242,6 +242,12 @@ export class SolendReserve {
         .dividedBy(WAD)
         .toNumber(),
       hostFeePercentage: parsedData.config.fees.hostFeePercentage / 100,
+      flashLoanFeePercentage: new BigNumber(
+        parsedData.config.fees.flashLoanFeeWad.toString()
+      )
+        .dividedBy(WAD)
+        .toNumber(),
+
       depositLimit: parsedData.config.depositLimit,
       reserveBorrowLimit: parsedData.config.borrowLimit,
 

--- a/solend-sdk/src/classes/shared.ts
+++ b/solend-sdk/src/classes/shared.ts
@@ -80,6 +80,7 @@ export type ReserveDataType = {
   optimalBorrowRate: number;
   maxBorrowRate: number;
   borrowFeePercentage: number;
+  flashLoanFeePercentage: number;
   hostFeePercentage: number;
   depositLimit: BN;
   reserveBorrowLimit: BN;


### PR DESCRIPTION
Intended: should be able to see the flashloanfeepercentage in the reserve config object, alongside borrowfeepercentage
actual: do not
fix: add it in as per chat in discord dev support

.. she builds I hope y'all enjoy